### PR TITLE
Use latest neow3j library (3.12.0)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation("commons-io:commons-io:2.10.0")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("com.google.code.gson:gson:2.8.7")
-    implementation("io.neow3j:contract:3.11.2") {
+    implementation("io.neow3j:contract:3.12.0") {
         exclude("org.slf4j")
     }
 }

--- a/src/main/java/org/neodapps/plugin/services/chain/BlockchainService.java
+++ b/src/main/java/org/neodapps/plugin/services/chain/BlockchainService.java
@@ -13,12 +13,12 @@ import io.neow3j.contract.Token;
 import io.neow3j.protocol.Neow3j;
 import io.neow3j.protocol.ObjectMapperFactory;
 import io.neow3j.protocol.core.response.ContractManifest;
+import io.neow3j.protocol.core.response.ExpressContractState;
 import io.neow3j.protocol.core.response.InvocationResult;
 import io.neow3j.protocol.core.response.NeoGetBlock;
-import io.neow3j.protocol.core.response.NeoGetContractState;
 import io.neow3j.protocol.core.response.NeoSendRawTransaction;
 import io.neow3j.protocol.http.HttpService;
-import io.neow3j.transaction.Signer;
+import io.neow3j.transaction.AccountSigner;
 import io.neow3j.types.ContractParameter;
 import io.neow3j.types.Hash160;
 import io.neow3j.wallet.Wallet;
@@ -101,7 +101,7 @@ public class BlockchainService {
       new ContractManagement(neow3j)
           .deploy(nefFile, manifest)
           .wallet(wallet)
-          .signers(Signer.global(wallet.getAccounts().get(0).getScriptHash()))
+          .signers(AccountSigner.global(wallet.getAccounts().get(0).getScriptHash()))
           .sign()
           .send();
       NeoNotifier.notifySuccess(project,
@@ -157,7 +157,7 @@ public class BlockchainService {
    * @param nep6Wallet     wallet to sign
    */
   public NeoSendRawTransaction.RawTransaction invokeContractMethod(
-      ChainLike chain, NeoGetContractState.ContractState contractState,
+      ChainLike chain, ExpressContractState contractState,
       ContractManifest.ContractABI.ContractMethod methodToInvoke,
       List<ContractParameter> parameters, NEP6Wallet nep6Wallet) {
     var neow3j = project.getService(UtilService.class).getNeow3jInstance(chain);
@@ -173,7 +173,7 @@ public class BlockchainService {
       return new SmartContract(contractState.getHash(), neow3j)
           .invokeFunction(methodToInvoke.getName(), parameters.toArray(ContractParameter[]::new))
           .wallet(wallet)
-          .signers(Signer.calledByEntry(wallet.getAccounts().get(0)))
+          .signers(AccountSigner.calledByEntry(wallet.getAccounts().get(0)))
           .sign().send().getSendRawTransaction();
     } catch (Throwable throwable) {
       NeoNotifier.notifyError(project, throwable.getMessage());
@@ -193,7 +193,7 @@ public class BlockchainService {
    * @param nep6Wallet     wallet to sign
    */
   public InvocationResult testInvokeContractMethod(
-      ChainLike chain, NeoGetContractState.ContractState contractState,
+      ChainLike chain, ExpressContractState contractState,
       ContractManifest.ContractABI.ContractMethod methodToInvoke,
       List<ContractParameter> parameters, NEP6Wallet nep6Wallet) {
     var neow3j = project.getService(UtilService.class).getNeow3jInstance(chain);
@@ -208,7 +208,7 @@ public class BlockchainService {
     try {
       return new SmartContract(contractState.getHash(), neow3j)
           .callInvokeFunction(methodToInvoke.getName(), parameters,
-              Signer.calledByEntry(wallet.getAccounts().get(0).getScriptHash()))
+              AccountSigner.calledByEntry(wallet.getAccounts().get(0).getScriptHash()))
           .getInvocationResult();
     } catch (Throwable throwable) {
       NeoNotifier.notifyError(project, throwable.getMessage());
@@ -272,7 +272,7 @@ public class BlockchainService {
       // do not use the util.getmagicnumber function here
       magicNumber =
           Integer.toUnsignedLong(
-              ByteBuffer.wrap(neow3j.getNetworkMagicNumber()).order(ByteOrder.LITTLE_ENDIAN)
+              ByteBuffer.wrap(neow3j.getNetworkMagicNumberBytes()).order(ByteOrder.LITTLE_ENDIAN)
                   .getInt());
     } catch (IOException e) {
       return NodeRunningState.NOT_RUNNING;

--- a/src/main/java/org/neodapps/plugin/services/chain/UtilService.java
+++ b/src/main/java/org/neodapps/plugin/services/chain/UtilService.java
@@ -64,7 +64,7 @@ public class UtilService {
     }
     try {
       return Integer.toUnsignedLong(
-          ByteBuffer.wrap(neow3j.getNetworkMagicNumber()).order(ByteOrder.LITTLE_ENDIAN)
+          ByteBuffer.wrap(neow3j.getNetworkMagicNumberBytes()).order(ByteOrder.LITTLE_ENDIAN)
               .getInt());
     } catch (IOException e) {
       NeoNotifier.notifyError(project, e.getMessage());

--- a/src/main/java/org/neodapps/plugin/ui/details/contracts/ContractsComponent.java
+++ b/src/main/java/org/neodapps/plugin/ui/details/contracts/ContractsComponent.java
@@ -17,7 +17,7 @@ import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.panels.Wrapper;
 import com.intellij.util.ui.JBUI;
-import io.neow3j.protocol.core.response.NeoGetContractState;
+import io.neow3j.protocol.core.response.ExpressContractState;
 import io.neow3j.wallet.nep6.NEP6Wallet;
 import java.awt.FlowLayout;
 import java.io.IOException;
@@ -73,10 +73,10 @@ public class ContractsComponent extends Wrapper implements Disposable {
 
   private void loadAndSetContent() {
     var worker =
-        new SwingWorker<Pair<List<NEP6Wallet>, List<NeoGetContractState.ContractState>>, Void>() {
+        new SwingWorker<Pair<List<NEP6Wallet>, List<ExpressContractState>>, Void>() {
           @Override
           protected Pair<List<NEP6Wallet>,
-              List<NeoGetContractState.ContractState>> doInBackground() {
+              List<ExpressContractState>> doInBackground() {
             return new Pair<>(project.getService(WalletService.class).getWallets(chain),
                 project.getService(ContractServices.class).getContracts(chain));
           }
@@ -106,7 +106,7 @@ public class ContractsComponent extends Wrapper implements Disposable {
   }
 
   private JComponent getToolBar(List<NEP6Wallet> wallets,
-                                List<NeoGetContractState.ContractState> contracts) {
+                                List<ExpressContractState> contracts) {
     // toolbar has two buttons
     var buttonPanel = JBUI.Panels.simplePanel();
     buttonPanel.setLayout(new FlowLayout());
@@ -152,7 +152,7 @@ public class ContractsComponent extends Wrapper implements Disposable {
   }
 
   private void openInvokeFile(VirtualFile file, List<NEP6Wallet> wallets,
-                              List<NeoGetContractState.ContractState> contracts) {
+                              List<ExpressContractState> contracts) {
     var worker = new SwingWorker<InvokeFile, Void>() {
       @Override
       protected InvokeFile doInBackground() {

--- a/src/main/java/org/neodapps/plugin/ui/details/contracts/invoke/InvokeFileComponent.java
+++ b/src/main/java/org/neodapps/plugin/ui/details/contracts/invoke/InvokeFileComponent.java
@@ -13,7 +13,7 @@ import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.ui.components.panels.Wrapper;
 import com.intellij.util.ui.JBUI;
-import io.neow3j.protocol.core.response.NeoGetContractState;
+import io.neow3j.protocol.core.response.ExpressContractState;
 import io.neow3j.wallet.nep6.NEP6Wallet;
 import java.awt.FlowLayout;
 import java.io.IOException;
@@ -39,7 +39,7 @@ public class InvokeFileComponent extends Wrapper implements Disposable {
   private final ChainLike chain;
   private final InvokeFile invokeFile;
   private final List<NEP6Wallet> wallets;
-  private final List<NeoGetContractState.ContractState> contracts;
+  private final List<ExpressContractState> contracts;
 
   private Wrapper mainPanel;
   private Wrapper itemListWrapper;
@@ -60,7 +60,7 @@ public class InvokeFileComponent extends Wrapper implements Disposable {
                              ChainLike chain,
                              InvokeFile invokeFile,
                              List<NEP6Wallet> wallets,
-                             List<NeoGetContractState.ContractState> contractList) {
+                             List<ExpressContractState> contractList) {
     this.project = project;
     this.chain = chain;
     this.invokeFile = invokeFile;
@@ -131,9 +131,7 @@ public class InvokeFileComponent extends Wrapper implements Disposable {
         AllIcons.General.Add, e -> addStep());
     titlePanel.add(addStepButton);
 
-    items.forEach((id, item) -> {
-      addInvokeItemToPanel(item);
-    });
+    items.forEach((id, item) -> addInvokeItemToPanel(item));
     return panel;
   }
 

--- a/src/main/java/org/neodapps/plugin/ui/details/contracts/invoke/InvokeItemComponent.java
+++ b/src/main/java/org/neodapps/plugin/ui/details/contracts/invoke/InvokeItemComponent.java
@@ -11,7 +11,7 @@ import com.intellij.ui.components.panels.Wrapper;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import io.neow3j.protocol.core.response.ContractManifest;
-import io.neow3j.protocol.core.response.NeoGetContractState;
+import io.neow3j.protocol.core.response.ExpressContractState;
 import io.neow3j.types.ContractParameter;
 import io.neow3j.types.ContractParameterType;
 import io.neow3j.types.Hash160;
@@ -39,7 +39,7 @@ public class InvokeItemComponent extends Wrapper implements Disposable {
   private final Project project;
   private final ChainLike chain;
   private final InvokeFileItem item;
-  private final List<NeoGetContractState.ContractState> deployedContracts;
+  private final List<ExpressContractState> deployedContracts;
   private final List<NEP6Wallet> availableWallets;
   private final InvokeItemAction invokeItemAction;
 
@@ -51,7 +51,7 @@ public class InvokeItemComponent extends Wrapper implements Disposable {
   private Wrapper argsPanel;
   private ToolWindowButton runStepButton;
 
-  private NeoGetContractState.ContractState selectedContract;
+  private ExpressContractState selectedContract;
   private ContractManifest.ContractABI.ContractMethod selectedOperation;
   private List<ArgumentField> argumentFields;
 
@@ -62,7 +62,7 @@ public class InvokeItemComponent extends Wrapper implements Disposable {
                              ChainLike chain,
                              InvokeFileItem item,
                              InvokeItemAction invokeItemAction,
-                             List<NeoGetContractState.ContractState> deployedContracts,
+                             List<ExpressContractState> deployedContracts,
                              List<NEP6Wallet> availableWallets) {
     this.project = project;
     this.chain = chain;

--- a/src/main/java/org/neodapps/plugin/ui/details/contracts/invoke/InvokeItemRunPopup.java
+++ b/src/main/java/org/neodapps/plugin/ui/details/contracts/invoke/InvokeItemRunPopup.java
@@ -11,8 +11,8 @@ import com.intellij.ui.components.JBList;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import io.neow3j.protocol.core.response.ContractManifest;
+import io.neow3j.protocol.core.response.ExpressContractState;
 import io.neow3j.protocol.core.response.InvocationResult;
-import io.neow3j.protocol.core.response.NeoGetContractState;
 import io.neow3j.types.ContractParameter;
 import io.neow3j.wallet.nep6.NEP6Wallet;
 import java.util.List;
@@ -34,7 +34,7 @@ public class InvokeItemRunPopup implements Disposable {
   private final Project project;
   private final ChainLike chain;
   private final List<NEP6Wallet> wallets;
-  NeoGetContractState.ContractState contractState;
+  ExpressContractState contractState;
   ContractManifest.ContractABI.ContractMethod method;
   List<ContractParameter> parameters;
 
@@ -46,7 +46,7 @@ public class InvokeItemRunPopup implements Disposable {
    */
   public InvokeItemRunPopup(Project project, ChainLike chain,
                             List<NEP6Wallet> wallets,
-                            NeoGetContractState.ContractState contractState,
+                            ExpressContractState contractState,
                             ContractManifest.ContractABI.ContractMethod method,
                             List<ContractParameter> parameters) {
     this.project = project;

--- a/src/main/java/org/neodapps/plugin/ui/details/contracts/invoke/TestInvokeComponentPopup.java
+++ b/src/main/java/org/neodapps/plugin/ui/details/contracts/invoke/TestInvokeComponentPopup.java
@@ -13,8 +13,8 @@ import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import io.neow3j.crypto.Base64;
 import io.neow3j.protocol.core.response.ContractManifest;
+import io.neow3j.protocol.core.response.ExpressContractState;
 import io.neow3j.protocol.core.response.InvocationResult;
-import io.neow3j.protocol.core.response.NeoGetContractState;
 import io.neow3j.protocol.core.response.NeoSendRawTransaction;
 import io.neow3j.protocol.core.stackitem.StackItem;
 import io.neow3j.script.ScriptReader;
@@ -41,7 +41,7 @@ public class TestInvokeComponentPopup implements Disposable {
   private final ChainLike chain;
 
   private final InvocationResult invocationResult;
-  private final NeoGetContractState.ContractState contractState;
+  private final ExpressContractState contractState;
   private final ContractManifest.ContractABI.ContractMethod method;
   private final List<ContractParameter> parameters;
   private final NEP6Wallet wallet;
@@ -55,7 +55,7 @@ public class TestInvokeComponentPopup implements Disposable {
    */
   public TestInvokeComponentPopup(Project project, ChainLike chain,
                                   InvocationResult result,
-                                  NeoGetContractState.ContractState contractState,
+                                  ExpressContractState contractState,
                                   ContractManifest.ContractABI.ContractMethod method,
                                   List<ContractParameter> parameters, NEP6Wallet wallet) {
     this.project = project;

--- a/src/main/java/org/neodapps/plugin/ui/details/contracts/list/DeployedContractListComponent.java
+++ b/src/main/java/org/neodapps/plugin/ui/details/contracts/list/DeployedContractListComponent.java
@@ -15,7 +15,7 @@ import com.intellij.ui.components.panels.Wrapper;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import io.neow3j.protocol.core.response.ContractManifest;
-import io.neow3j.protocol.core.response.NeoGetContractState;
+import io.neow3j.protocol.core.response.ExpressContractState;
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.util.List;
@@ -29,7 +29,7 @@ import org.neodapps.plugin.NeoMessageBundle;
  */
 public class DeployedContractListComponent extends Wrapper implements Disposable {
 
-  private final List<NeoGetContractState.ContractState> contracts;
+  private final List<ExpressContractState> contracts;
 
   private JBSplitter panel;
   private Wrapper details;
@@ -37,7 +37,7 @@ public class DeployedContractListComponent extends Wrapper implements Disposable
   /**
    * Creates the component that shows deployed contracts.
    */
-  public DeployedContractListComponent(List<NeoGetContractState.ContractState> deployedContracts) {
+  public DeployedContractListComponent(List<ExpressContractState> deployedContracts) {
     this.contracts = deployedContracts;
 
     this.panel = new JBSplitter(0.2f);
@@ -71,7 +71,7 @@ public class DeployedContractListComponent extends Wrapper implements Disposable
     return panel;
   }
 
-  private void showDetails(NeoGetContractState.ContractState selected) {
+  private void showDetails(ExpressContractState selected) {
     final var panel = JBUI.Panels.simplePanel();
     var builder = new FormBuilder();
     var contractName = new JBLabel(selected.getManifest().getName());


### PR DESCRIPTION
 - Uses `Neow3jExpress` to get contracts instead of manually calling RPC endpoint.
 - Other minor syntax changes (Signer -> Account Signer)